### PR TITLE
Don't extend classes

### DIFF
--- a/temper-pygments/pyproject.toml
+++ b/temper-pygments/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "temper-pygments"
-version = "0.1.1"
+version = "0.1.2"
 description = ""
 authors = ["Tom <tom@temper.systems>"]
 readme = "README.md"
@@ -9,8 +9,8 @@ packages = [{include = "temper_pygments"}]
 [tool.poetry.dependencies]
 python = "^3.8"
 pygments = "^2.12.0"
-temper-core = "0.0.5"
-temper-syntax = "0.1.1"
+temper-core = "0.0.6"
+temper-syntax = "0.1.2"
 
 [tool.poetry.plugins."pygments.lexers"]
 temper = "temper_pygments:TemperLexer"

--- a/temper-syntax/config.temper.md
+++ b/temper-syntax/config.temper.md
@@ -1,7 +1,7 @@
 # Temper Syntax
 
     export let name = "temper-syntax";
-    export let version = "0.1.1";
+    export let version = "0.1.2";
 
 This temper library supports syntax highlighting for multiple backends and
 frameworks. The intent is that some shared definitions can be used despite the

--- a/temper-syntax/pygments.temper.md
+++ b/temper-syntax/pygments.temper.md
@@ -4,7 +4,7 @@
 
 Use a marker interface for various kinds of rules.
 
-    export /*sealed*/ class RuleOption {}
+    export /*sealed*/ interface RuleOption {}
 
 ### Rule
 
@@ -30,7 +30,7 @@ You can also include other states into a state.
 
 Or inherit from other base class rules.
 
-    export class Inherit extends Rule {}
+    export class Inherit extends RuleOption {}
     export let inherit = new Inherit();
 
 ## Token Kinds


### PR DESCRIPTION
Some of the things I did in testing this (skipping some details):

```
temper-syntax> temper build
temper-syntax> cd .\temper.out\
temper-syntax\temper-pygments> poetry install
temper-syntax\temper-pygments> poetry run pip install --editable ..\temper.out\py\temper-syntax\
temper-syntax\temper-pygments> poetry run test
.....
----------------------------------------------------------------------
Ran 5 tests in 0.014s

OK
```