### PR TITLE
Use List.of instead of casting

### DIFF
--- a/temper-pygments/pyproject.toml
+++ b/temper-pygments/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "temper-pygments"
-version = "0.2.2"
+version = "0.2.3"
 description = ""
 authors = ["Tom <tom@temper.systems>"]
 readme = "README.md"
@@ -10,7 +10,7 @@ packages = [{include = "temper_pygments"}]
 python = "^3.8"
 pygments = "^2.12.0"
 temper-core = "0.4.0"
-temper-syntax = "0.2.2"
+temper-syntax = "0.2.3"
 
 [tool.poetry.plugins."pygments.lexers"]
 temper = "temper_pygments:TemperLexer"

--- a/temper-syntax/config.temper.md
+++ b/temper-syntax/config.temper.md
@@ -1,7 +1,7 @@
 # Temper Syntax
 
     export let name = "temper-syntax";
-    export let version = "0.2.2";
+    export let version = "0.2.3";
 
 This temper library supports syntax highlighting for multiple backends and
 frameworks. The intent is that some shared definitions can be used despite the

--- a/temper-syntax/temper-pygments/temper-pygments.temper.md
+++ b/temper-syntax/temper-pygments/temper-pygments.temper.md
@@ -25,7 +25,7 @@ Main thing, though, is the list of rules for definition tokens.
 
 #### Root
 
-        new Pair("root", [
+        new Pair("root", List.of<RuleOption>(
           include("commentsandwhitespace"),
           new Rule(
             words("false", "NaN", "null", "true", "void"),
@@ -60,15 +60,15 @@ Main thing, though, is the list of rules for definition tokens.
           new Rule(raw"\d+\.?\d*|\.\d+", Kind.number),
           new Rule("@${nameRegex}", Kind.nameDecorator),
           new Rule(nameRegex, Kind.nameKind),
-        ].as<List<RuleOption>>() orelse panic()),
+        )),
 
 #### Comments and Whitespace
 
-        new Pair("commentsandwhitespace", [
+        new Pair("commentsandwhitespace", List.of<RuleOption>(
           new Rule(raw"\s+", Kind.whitespace),
           new Rule("//.*?$", Kind.commentSingleline),
           new Rule(raw"/\*", Kind.commentMultiline, "nestedcomment"),
-        ].as<List<RuleOption>>() orelse panic()),
+        )),
 
 #### Multiline/Nested Comments
 
@@ -76,16 +76,16 @@ We plan to support nested comments soon, so just implement that already here.
 The technique here is based on the `nestedcomment` for the [D Language lexer for
 Pygments][dlang-nestedcomment].
 
-        new Pair("nestedcomment", [
+        new Pair("nestedcomment", List.of<RuleOption>(
           new Rule(raw"[^*/]+", Kind.commentMultiline),
           new Rule(raw"/\*", Kind.commentMultiline, "#push"),
           new Rule(raw"\*/", Kind.commentMultiline, "#pop"),
           new Rule(raw"[*/]", Kind.commentMultiline),
-        ].as<List<RuleOption>>() orelse panic()),
+        )),
 
 #### Regex Literals
 
-        new Pair("slashstartsregex", [
+        new Pair("slashstartsregex", List.of<RuleOption>(
           include("commentsandwhitespace"),
           new Rule(
             // Copied from pygments js lexer.
@@ -94,14 +94,14 @@ Pygments][dlang-nestedcomment].
             "#pop",
           ),
           default("#pop"),
-        ].as<List<RuleOption>>() orelse panic()),
+        )),
 
 #### Strings
 
-        new Pair("interpolation", [
+        new Pair("interpolation", List.of<RuleOption>(
           new Rule("}", Kind.stringInterpol, "#pop"),
           include("root"),
-        ].as<List<RuleOption>>() orelse panic()),
+        )),
         stringish("string", Kind.stringPlain),
         stringish("stringregex", Kind.stringRegex),
 
@@ -129,11 +129,11 @@ And use a support function to customise the token kind for `rgx` strings.
 I'm not sure if order matters here. Seems simpler, but if I don't exclude `${`
 from core string chars, I don't get interp.
 
-      new Pair(key, [
+      new Pair(key, List.of<RuleOption>(
         new Rule("\"", kind, "#pop"),
         new Rule(raw"\$\{", Kind.stringInterpol, "interpolation"),
         new Rule("(?:[^\"$]|\\$[^{])+", kind),
-      ].as<List<RuleOption>>() orelse panic())
+      ))
     }
 
 ### Word lists

--- a/temper-syntax/temper-pygments/tempermd-pygments.temper.md
+++ b/temper-syntax/temper-pygments/tempermd-pygments.temper.md
@@ -9,7 +9,7 @@ metadata central to the Temper Syntax library is still nice.
       public filenames: List<String> = ["*.temper.md", "*.tempermd"];
 
       public tokens: Map<String, List<RuleOption>> = new Map([
-        new Pair("root", [
+        new Pair("root", List.of<RuleOption>(
 
 To find indentation, use relatively simple 4 spaces from start for now. I don't
 think Pygment's MarkdownLexer even recognizing indented code blocks at all right
@@ -19,9 +19,9 @@ TODO Recognize indentation relative to previous, such as outlines.
 
           new Rule(raw"^\s*\n {4}", Kind.whitespace, "indented"),
           inherit,
-        ].as<List<RuleOption>>() orelse panic()),
+        )),
 
-        new Pair("indented", [
+        new Pair("indented", List.of<RuleOption>(
           new Rule(
 
 This seems to recognize the end of indented sections ok for the moment, limited
@@ -31,6 +31,6 @@ to 4-space indentation from line start for now.
             bygroups([using("Temper")]),
             "#pop",
           ),
-        ].as<List<RuleOption>>() orelse panic()),
+        )),
       ]);
     }


### PR DESCRIPTION
- Fix errors in Temper-built Rust code