### PR TITLE
Improve numbers; nest curlies in string interp

### DIFF
--- a/temper-pygments/poetry.lock
+++ b/temper-pygments/poetry.lock
@@ -41,14 +41,14 @@ files = [
 
 [[package]]
 name = "temper-syntax"
-version = "0.6.1"
+version = "0.6.2"
 description = ""
 optional = false
 python-versions = ">=3.11"
 groups = ["main"]
 files = [
-    {file = "temper_syntax-0.6.1-py3-none-any.whl", hash = "sha256:1013e147a8af042819b87bedc5c3bb4d6f9648734fdbe1c65c8236cf56fe4ffe"},
-    {file = "temper_syntax-0.6.1.tar.gz", hash = "sha256:ef54df1ab765dfd5cf3b957e52066184b5866f8647cb73438ac9aeb00dcdba64"},
+    {file = "temper_syntax-0.6.2-py3-none-any.whl", hash = "sha256:a7be421275b0ee83c0921adba9d5fc16b4baa255138f8a763abf808176586b0b"},
+    {file = "temper_syntax-0.6.2.tar.gz", hash = "sha256:9036a5b599e60ae7fe445909ef6c0e9f5ecdf41bbffd3519e30ae99eb857ba9f"},
 ]
 
 [package.dependencies]
@@ -57,4 +57,4 @@ temper-core = "0.6.0"
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.11"
-content-hash = "de9c9691a4716f0491860d74b80ca7b548c0d0a8de243483d66b763fa302ebed"
+content-hash = "a25ed0f730991d768b3a35951a7511380769c0a6fe75c581b8a3a95db2491fa8"

--- a/temper-pygments/pyproject.toml
+++ b/temper-pygments/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "temper-pygments"
-version = "0.6.1"
+version = "0.6.2"
 description = ""
 authors = ["Tom <tom@temper.systems>"]
 readme = "README.md"
@@ -10,7 +10,7 @@ packages = [{include = "temper_pygments"}]
 python = "^3.11"
 pygments = "^2.12.0"
 temper-core = "0.6.0"
-temper-syntax = "0.6.1"
+temper-syntax = "0.6.2"
 # temper-syntax = { path = "../temper.out/py/temper-syntax", develop = true }
 
 [tool.poetry.plugins."pygments.lexers"]

--- a/temper-pygments/tests/test_temper.py
+++ b/temper-pygments/tests/test_temper.py
@@ -100,7 +100,7 @@ class TemperLexerTest(unittest.TestCase):
             dedent(
                 """
                 let name = "world";
-                console.log("Hello ${name} for $5.");
+                console.log("Hello ${[name].join(", ") { x => x }} for $5.");
                 """
             )
         )
@@ -123,7 +123,26 @@ class TemperLexerTest(unittest.TestCase):
             (Token.Literal.String, '"'),
             (Token.Literal.String, "Hello "),
             (Token.Literal.String.Interpol, "${"),
+            (Token.Punctuation, "["),
             (Token.Name, "name"),
+            (Token.Punctuation, "]"),
+            (Token.Punctuation, "."),
+            (Token.Name, "join"),
+            (Token.Punctuation, "("),
+            (Token.Literal.String, '"'),
+            (Token.Literal.String, ", "),
+            (Token.Literal.String, '"'),
+            (Token.Punctuation, ")"),
+            (Token.Whitespace, " "),
+            (Token.Punctuation, "{"),
+            (Token.Whitespace, " "),
+            (Token.Name, "x"),
+            (Token.Whitespace, " "),
+            (Token.Operator, "=>"),
+            (Token.Whitespace, " "),
+            (Token.Name, "x"),
+            (Token.Whitespace, " "),
+            (Token.Punctuation, "}"),
             (Token.Literal.String.Interpol, "}"),
             (Token.Literal.String, " for $5."),
             (Token.Literal.String, '"'),

--- a/temper-pygments/tests/test_temper.py
+++ b/temper-pygments/tests/test_temper.py
@@ -15,6 +15,7 @@ class TemperLexerTest(unittest.TestCase):
                 Comment here. */ a; */ let m = n + 5;
                 let p = 0xA_BC12;
                 let q = 1.5e-34;
+                let r = 1.toString();
                 """
             )
         )
@@ -67,6 +68,19 @@ class TemperLexerTest(unittest.TestCase):
             (Token.Operator, "="),
             (Token.Whitespace, " "),
             (Token.Literal.Number, "1.5e-34"),
+            (Token.Punctuation, ";"),
+            (Token.Whitespace, "\n"),
+            (Token.Keyword.Declaration, "let"),
+            (Token.Whitespace, " "),
+            (Token.Name, "r"),
+            (Token.Whitespace, " "),
+            (Token.Operator, "="),
+            (Token.Whitespace, " "),
+            (Token.Literal.Number, "1"),
+            (Token.Punctuation, "."),
+            (Token.Name, "toString"),
+            (Token.Punctuation, "("),
+            (Token.Punctuation, ")"),
             (Token.Punctuation, ";"),
             (Token.Whitespace, "\n"),
         ]

--- a/temper-pygments/tests/test_temper.py
+++ b/temper-pygments/tests/test_temper.py
@@ -10,9 +10,11 @@ class TemperLexerTest(unittest.TestCase):
         tokens = lexer.get_tokens(
             dedent(
                 """
-                let n = 5; // Comment
+                let n = 5_000i32; // Comment
                 /* Longer /*
                 Comment here. */ a; */ let m = n + 5;
+                let p = 0xA_BC12;
+                let q = 1.5e-34;
                 """
             )
         )
@@ -23,7 +25,7 @@ class TemperLexerTest(unittest.TestCase):
             (Token.Whitespace, " "),
             (Token.Operator, "="),
             (Token.Whitespace, " "),
-            (Token.Literal.Number, "5"),
+            (Token.Literal.Number, "5_000i32"),
             (Token.Punctuation, ";"),
             (Token.Whitespace, " "),
             (Token.Comment.Singleline, "// Comment"),
@@ -49,8 +51,26 @@ class TemperLexerTest(unittest.TestCase):
             (Token.Literal.Number, "5"),
             (Token.Punctuation, ";"),
             (Token.Whitespace, "\n"),
+            (Token.Keyword.Declaration, "let"),
+            (Token.Whitespace, " "),
+            (Token.Name, "p"),
+            (Token.Whitespace, " "),
+            (Token.Operator, "="),
+            (Token.Whitespace, " "),
+            (Token.Literal.Number, "0xA_BC12"),
+            (Token.Punctuation, ";"),
+            (Token.Whitespace, "\n"),
+            (Token.Keyword.Declaration, "let"),
+            (Token.Whitespace, " "),
+            (Token.Name, "q"),
+            (Token.Whitespace, " "),
+            (Token.Operator, "="),
+            (Token.Whitespace, " "),
+            (Token.Literal.Number, "1.5e-34"),
+            (Token.Punctuation, ";"),
+            (Token.Whitespace, "\n"),
         ]
-        # print([*tokens])
+        # import pprint; pprint.pprint([*tokens])
         self.assertEqual(expected, [*tokens])
 
     def test_comment_excess(self):

--- a/temper-syntax/config.temper.md
+++ b/temper-syntax/config.temper.md
@@ -1,7 +1,7 @@
 # Temper Syntax
 
     export let name = "temper-syntax";
-    export let version = "0.6.1";
+    export let version = "0.6.2";
 
 This temper library supports syntax highlighting for multiple backends and
 frameworks. The intent is that some shared definitions can be used despite the

--- a/temper-syntax/temper-pygments/temper-pygments.temper.md
+++ b/temper-syntax/temper-pygments/temper-pygments.temper.md
@@ -170,7 +170,7 @@ Pygments][dlang-nestedcomment].
 Digit followed by word chars supports `i64`-style suffices and also hex. It's
 overly accepting, but that's ok here.
 
-          raw"(?:\d[_\d]*\.?[_\d]*|\.\d[_\d]*)(?:e[+-]?\d+)?\w*",
+          raw"(?:\d[_\d]*(:?\.?\d[_\d]*)?|\.\d[_\d]*)(?:e[+-]?\d+)?\w*",
           Kind.number,
         ),
         new Rule("@${nameRegex}", Kind.nameDecorator),

--- a/temper-syntax/temper-pygments/temper-pygments.temper.md
+++ b/temper-syntax/temper-pygments/temper-pygments.temper.md
@@ -97,7 +97,13 @@ Pygments][dlang-nestedcomment].
           include("rootinline"),
         )),
         new Pair("interpolation", List.of<RuleOption>(
+          new Rule(raw"\{", Kind.punctuation, "interpolationdepth"),
           new Rule("}", Kind.stringInterpol, "#pop"),
+          include("root"),
+        )),
+        new Pair("interpolationdepth", List.of<RuleOption>(
+          new Rule(raw"\{", Kind.punctuation, "#push"),
+          new Rule("}", Kind.punctuation, "#pop"),
           include("root"),
         )),
         stringish("string", Kind.stringPlain),
@@ -158,7 +164,7 @@ Pygments][dlang-nestedcomment].
         new Rule("\"\"\"", Kind.stringPlain, "stringmulti"),
         new Rule("\"", Kind.stringPlain, "string"),
         new Rule("[-=+*&|<>]+|/=?", Kind.operator, regexOption),
-        new Rule("[{}();:.,]", Kind.punctuation, regexOption),
+        new Rule(raw"[\[\]{}();:.,]", Kind.punctuation, regexOption),
         new Rule(
 
 Digit followed by word chars supports `i64`-style suffices and also hex. It's

--- a/temper-syntax/temper-pygments/temper-pygments.temper.md
+++ b/temper-syntax/temper-pygments/temper-pygments.temper.md
@@ -159,7 +159,14 @@ Pygments][dlang-nestedcomment].
         new Rule("\"", Kind.stringPlain, "string"),
         new Rule("[-=+*&|<>]+|/=?", Kind.operator, regexOption),
         new Rule("[{}();:.,]", Kind.punctuation, regexOption),
-        new Rule(raw"\d+\.?\d*|\.\d+", Kind.number),
+        new Rule(
+
+Digit followed by word chars supports `i64`-style suffices and also hex. It's
+overly accepting, but that's ok here.
+
+          raw"(?:\d[_\d]*\.?[_\d]*|\.\d[_\d]*)(?:e[+-]?\d+)?\w*",
+          Kind.number,
+        ),
         new Rule("@${nameRegex}", Kind.nameDecorator),
         new Rule(nameRegex, Kind.nameKind),
       ))      


### PR DESCRIPTION
TLD example before:

<img width="2470" height="1445" alt="image" src="https://github.com/user-attachments/assets/9d10c67c-086a-4c2f-ae53-3ccaa41b23e5" />

And after:

<img width="2470" height="1445" alt="image" src="https://github.com/user-attachments/assets/57ebc0a4-731d-49e7-93c8-1405480872cd" />

I don't know why the copy buttons are different between the two. I don't see how it would relate to me changes here. But the number coloring changes are relevant.

And we could get fancier, but even just single color for the whole literal looks nicer to me than only coloring the leading `0` in hex, for example, or dropping at the first `_`.

Also improved string interp. Before:

<img width="1036" height="203" alt="image" src="https://github.com/user-attachments/assets/6181874e-8c3c-4b52-8f30-e014a448c0b3" />

And after:

<img width="1041" height="201" alt="image" src="https://github.com/user-attachments/assets/ab0fb3fa-d2de-4dbb-9c0e-a42251a09b94" />

And here's python test results:

```
temper-syntax\temper-pygments> poetry run tempyg-test
.......
----------------------------------------------------------------------
Ran 7 tests in 0.010s

OK
```